### PR TITLE
fix: allow empty commit when running 'Build and push to budget-manage…

### DIFF
--- a/.github/workflows/build-client-to-server.yml
+++ b/.github/workflows/build-client-to-server.yml
@@ -40,5 +40,5 @@ jobs:
           git config --global user.email "ashotnazaryan45@gmail.com"
           git config --global user.name "anazaryan"
           git add .
-          git commit -m "Deploy Build"
+          git commit --allow-empty -m "Deploy Build"
           git push origin master


### PR DESCRIPTION
…ment-api' action